### PR TITLE
feat: add Figma node deep links to change reports

### DIFF
--- a/src/diff-engine.test.ts
+++ b/src/diff-engine.test.ts
@@ -612,4 +612,20 @@ describe("node links in reports", () => {
       .join("\n");
     expect(content).toContain("<https://www.figma.com/design/abc123?node-id=1-2|Button>");
   });
+
+  it("escapes special characters in node names for Slack links", () => {
+    const specialChanges = [
+      {
+        pageName: "Home",
+        nodeId: "1:2",
+        nodeName: "Icon <beta> | v2 & more",
+        nodeType: "FRAME",
+        kind: "added" as const,
+      },
+    ];
+    const report = formatSlackReport("abc123", specialChanges);
+    // Display text should have escaped special chars
+    expect(report).toContain("Icon &lt;beta&gt; │ v2 &amp; more");
+    expect(report).toContain("│"); // pipe replaced with box drawing char
+  });
 });

--- a/src/diff-engine.ts
+++ b/src/diff-engine.ts
@@ -306,7 +306,7 @@ export function formatSlackReport(
       const first = nodeChanges[0];
 
       if (nodeChanges.length > 5) {
-        const link = `<${nodeUrl(fileKey, first.nodeId)}|${first.nodeName}>`;
+        const link = slackNodeLink(fileKey, first.nodeId, first.nodeName);
         lines.push(
           `  📦 ${link} (${first.nodeType}): ${nodeChanges.length} changes`,
         );
@@ -318,7 +318,7 @@ export function formatSlackReport(
           ? propertyLabel(change.property)
           : "";
         const overrideTag = change.isOverride ? " _[override]_" : "";
-        const link = `<${nodeUrl(fileKey, change.nodeId)}|${change.nodeName}>`;
+        const link = slackNodeLink(fileKey, change.nodeId, change.nodeName);
         if (change.kind === "added") {
           lines.push(
             `  ➕ ${link} (${change.nodeType}) added`,
@@ -408,7 +408,7 @@ export function formatSlackBlocks(
       const first = nodeChanges[0];
 
       if (nodeChanges.length > 5) {
-        const link = `<${nodeUrl(fileKey, first.nodeId)}|${first.nodeName}>`;
+        const link = slackNodeLink(fileKey, first.nodeId, first.nodeName);
         lines.push(
           `📦 ${link} (${first.nodeType}): ${nodeChanges.length} changes`,
         );
@@ -487,7 +487,7 @@ export function chunkLines(lines: string[], maxChars: number): string[] {
 function formatBlockKitChange(fileKey: string, change: ChangeEntry): string {
   const propLabel = change.property ? propertyLabel(change.property) : "";
   const overrideTag = change.isOverride ? " _[override]_" : "";
-  const link = `<${nodeUrl(fileKey, change.nodeId)}|${change.nodeName}>`;
+  const link = slackNodeLink(fileKey, change.nodeId, change.nodeName);
 
   switch (change.kind) {
     case "added":
@@ -616,6 +616,19 @@ function colorToHex(color: FigmaColor): string {
 
 export function nodeUrl(fileKey: string, nodeId: string): string {
   // Figma URLs use hyphen-separated node IDs (e.g., "1:2" → "1-2")
-  const encodedId = nodeId.replace(/:/g, "-");
+  const encodedId = encodeURIComponent(nodeId.replace(/:/g, "-"));
   return `https://www.figma.com/design/${fileKey}?node-id=${encodedId}`;
+}
+
+/** Escape text for use inside Slack mrkdwn link syntax `<url|text>` */
+function escapeSlackLinkText(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/\|/g, "│");
+}
+
+function slackNodeLink(fileKey: string, nodeId: string, nodeName: string): string {
+  return `<${nodeUrl(fileKey, nodeId)}|${escapeSlackLinkText(nodeName)}>`;
 }


### PR DESCRIPTION
## Summary
- Each change entry now links directly to the affected node in Figma
- Node IDs are converted to URL format (`1:2` → `1-2`)
- Links appear in all three report formats: console, Slack plain text, and Block Kit

Closes #10

## Test plan
- [x] 5 new tests (nodeUrl conversion, link presence in console/Slack/Block Kit)
- [x] All 40 tests passing
- [x] Lint + typecheck passing
- [ ] Manual Slack notification verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)