### PR TITLE
fix: template-syncワークフローのセットアップ問題を修正

### DIFF
--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -8,22 +8,32 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   template-sync:
     runs-on: ubuntu-latest
     if: github.repository != 'KdavisO/claude-project-template'
+    env:
+      SYNC_TOKEN: ${{ secrets.TEMPLATE_SYNC_TOKEN }}
     steps:
+      - name: Check token
+        if: env.SYNC_TOKEN == ''
+        run: |
+          echo "::warning::TEMPLATE_SYNC_TOKEN is not set. Skipping sync."
+          exit 0
+
       - uses: actions/checkout@v4
-        if: ${{ secrets.TEMPLATE_SYNC_TOKEN != '' }}
+        if: env.SYNC_TOKEN != ''
         with:
           token: ${{ secrets.TEMPLATE_SYNC_TOKEN }}
 
       - uses: AndreasAugustin/actions-template-sync@8ec19a5f2721ffb81ff809aa340ddf75e6a85ea6 # v2
-        if: ${{ secrets.TEMPLATE_SYNC_TOKEN != '' }}
+        if: env.SYNC_TOKEN != ''
         with:
           source_repo_path: KdavisO/claude-project-template
           upstream_branch: main
           pr_title: "chore: テンプレートリポジトリの更新を反映"
           pr_labels: chore,template-sync
           pr_commit_msg: "chore: sync with template repository"
+          github_token: ${{ secrets.TEMPLATE_SYNC_TOKEN }}


### PR DESCRIPTION
## Summary

テンプレートリポジトリ（KdavisO/claude-project-template#13）で修正された template-sync ワークフローの問題をこのリポジトリにも適用。

- secrets参照をenv変数経由に変更（`workflow_dispatch`でのバリデーションエラー回避）
- `permissions` に `issues: write` を追加（ラベル操作に必要）
- `github_token` パラメータにPATを渡す設定を追加（デフォルトGITHUB_TOKENの制限回避）

## 変更内容

- `.github/workflows/template-sync.yml`: secrets参照方法、権限、github_tokenの修正

## Test plan

- [ ] `gh workflow run template-sync.yml` で正常に同期PRが作成されることを確認
- [ ] secrets未設定時に警告が出てスキップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)