### PR TITLE
feat: 変更なし時のSlack通知

### DIFF
--- a/src/diff.ts
+++ b/src/diff.ts
@@ -46,7 +46,7 @@ import type { Config } from "./config.js";
 async function processFile(
   config: Config,
   fileKey: string,
-): Promise<{ fileKey: string; changes: ChangeEntry[]; editors: FigmaUser[] }> {
+): Promise<{ fileKey: string; changes: ChangeEntry[]; editors: FigmaUser[]; baselineCreated: boolean }> {
   // Load previous snapshot
   const previous = await loadSnapshot(config.snapshotDir, fileKey);
 
@@ -65,7 +65,7 @@ async function processFile(
       latestVersionId = versionCheck.latestVersionId;
       if (!versionCheck.changed) {
         console.log("  No version change detected — skipping snapshot comparison.");
-        return { fileKey, changes: [], editors: [] };
+        return { fileKey, changes: [], editors: [], baselineCreated: false };
       }
       console.log("  Version changed — fetching current state.");
     } catch (err) {
@@ -164,7 +164,7 @@ async function processFile(
 
   if (!previous) {
     console.log("  No previous snapshot found. First run — baseline saved.");
-    return { fileKey, changes: [], editors: [] };
+    return { fileKey, changes: [], editors: [], baselineCreated: true };
   }
 
   // Detect changes
@@ -188,14 +188,14 @@ async function processFile(
 
   console.log(report.summary);
 
-  return { fileKey, changes, editors };
+  return { fileKey, changes, editors, baselineCreated: false };
 }
 
 async function main(): Promise<void> {
   console.log("DesignDigest: Starting diff check...");
 
   const config = loadConfig();
-  const allChanges: { fileKey: string; changes: ChangeEntry[]; editors: FigmaUser[] }[] = [];
+  const allChanges: { fileKey: string; changes: ChangeEntry[]; editors: FigmaUser[]; baselineCreated: boolean }[] = [];
 
   for (const fileKey of config.figmaFileKeys) {
     console.log(
@@ -208,10 +208,13 @@ async function main(): Promise<void> {
   const totalChanges = allChanges.flatMap((r) => r.changes);
 
   if (totalChanges.length === 0) {
+    const isBaseline = allChanges.some((r) => r.baselineCreated);
     console.log("\nNo changes detected across all files.");
 
-    // Send "no changes" Slack notification
-    if (!config.dryRun && config.slackWebhookUrl) {
+    // Send "no changes" Slack notification (skip on baseline creation)
+    if (isBaseline) {
+      console.log("Baseline created — skipping Slack notification.");
+    } else if (!config.dryRun && config.slackWebhookUrl) {
       try {
         await sendSlackNotification(config.slackWebhookUrl, {
           text: "DesignDigest: No changes detected across all monitored files.",
@@ -220,6 +223,10 @@ async function main(): Promise<void> {
       } catch (err) {
         console.warn("Failed to send Slack notification:", err);
       }
+    } else if (config.dryRun) {
+      console.log("Dry run mode — skipping Slack notification.");
+    } else if (!config.slackWebhookUrl) {
+      console.log("No SLACK_WEBHOOK_URL configured — skipping notification.");
     }
 
     console.log("Done.");


### PR DESCRIPTION
## 概要

変更が検出されなかった場合に「No changes detected」の簡易Slack通知を送信する機能を追加。
日次cron実行時にツールが正常に動作しているかをSlackで確認できるようになる。

## 変更内容

- `src/diff.ts`: 変更なし時の早期リターン前にSlack通知を送信するロジックを追加

## テスト方法

1. `npm test` で全103テストがパスすることを確認
2. `npm run typecheck` で型チェックがパスすることを確認
3. `npm run lint` でlintがパスすることを確認
4. `SLACK_WEBHOOK_URL` を設定して `npm run diff:dry-run` を2回実行し、DRY_RUNモードではSlack通知がスキップされることを確認
5. `DRY_RUN=false` で変更なしの状態で実行し、Slackに「No changes detected」の通知が届くことを確認

Closes #30