### PR TITLE
Slack通知のアイコンをDesign Digest固有に設定

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,8 @@ FIGMA_FILE_KEY=
 
 # Optional: Slack notification
 # SLACK_WEBHOOK_URL=
+# SLACK_ICON_URL=https://example.com/icon.png
+# SLACK_ICON_EMOJI=:art:
 
 # Optional: AI summary
 # ANTHROPIC_API_KEY=

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,8 @@ export interface Config {
   figmaWatchPages: string[];
   figmaWatchNodeIds: string[];
   slackWebhookUrl: string | undefined;
+  slackIconUrl: string | undefined;
+  slackIconEmoji: string | undefined;
   anthropicApiKey: string | undefined;
   claudeSummaryEnabled: boolean;
   githubIssueEnabled: boolean;
@@ -36,6 +38,8 @@ export function loadConfig(): Config {
     figmaWatchPages: csvList("FIGMA_WATCH_PAGES"),
     figmaWatchNodeIds: csvList("FIGMA_WATCH_NODE_IDS"),
     slackWebhookUrl: process.env.SLACK_WEBHOOK_URL || undefined,
+    slackIconUrl: process.env.SLACK_ICON_URL || undefined,
+    slackIconEmoji: process.env.SLACK_ICON_EMOJI || undefined,
     anthropicApiKey: process.env.ANTHROPIC_API_KEY || undefined,
     claudeSummaryEnabled: process.env.CLAUDE_SUMMARY_ENABLED === "true",
     githubIssueEnabled: process.env.GITHUB_ISSUE_ENABLED === "true",

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -218,6 +218,8 @@ async function main(): Promise<void> {
       try {
         await sendSlackNotification(config.slackWebhookUrl, {
           text: "DesignDigest: No changes detected across all monitored files.",
+          icon_url: config.slackIconUrl,
+          icon_emoji: config.slackIconEmoji,
         });
         console.log("Slack notification sent (no changes).");
       } catch (err) {
@@ -294,6 +296,8 @@ async function main(): Promise<void> {
     await sendSlackNotification(config.slackWebhookUrl, {
       text: fallbackText,
       blocks,
+      icon_url: config.slackIconUrl,
+      icon_emoji: config.slackIconEmoji,
     });
     console.log("Slack notification sent.");
   } else if (config.dryRun) {
@@ -540,6 +544,8 @@ main().catch(async (err) => {
                 }]
               : []),
           ],
+          icon_url: process.env.SLACK_ICON_URL || undefined,
+          icon_emoji: process.env.SLACK_ICON_EMOJI || undefined,
         }, controller.signal);
         console.log("Error notification sent to Slack.");
       } finally {

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -3,6 +3,8 @@ import type { SlackBlock } from "./diff-engine.js";
 export interface SlackPayload {
   text: string;
   blocks?: SlackBlock[];
+  icon_url?: string;
+  icon_emoji?: string;
 }
 
 export async function sendSlackNotification(


### PR DESCRIPTION
## 概要
Slack通知のアイコンを環境変数でカスタマイズできるようにした。
`SLACK_ICON_URL` または `SLACK_ICON_EMOJI` を設定することで、Design Digest固有のアイコンで通知を表示できる。

## 変更内容
- `src/config.ts`: `slackIconUrl`, `slackIconEmoji` 設定を追加
- `src/notify.ts`: `SlackPayload` に `icon_url`, `icon_emoji` フィールドを追加
- `src/diff.ts`: 全3箇所の `sendSlackNotification` 呼び出しにアイコン設定を適用
- `.env.example`: 新規環境変数のドキュメントを追加

## テスト方法
- `npm run typecheck` — 型チェック通過
- `npm run lint` — lint通過
- `npm test` — 全103テスト通過
- `SLACK_ICON_URL` 設定時: Slack通知のアイコンがカスタムアイコンに変わることを確認
- `SLACK_ICON_EMOJI=:art:` 設定時: Slack通知のアイコンが指定絵文字に変わることを確認
- 未設定時: 既存動作に影響がないことを確認

Closes #34