### PR TITLE
変更なし時のSlack通知メッセージを簡潔にする

### DIFF
--- a/src/diff.ts
+++ b/src/diff.ts
@@ -209,7 +209,7 @@ async function main(): Promise<void> {
 
   if (totalChanges.length === 0) {
     const isBaseline = allChanges.some((r) => r.baselineCreated);
-    console.log("\nNo changes detected across all files.");
+    console.log("\n✅ No changes detected across all files.");
 
     // Send "no changes" Slack notification (skip on baseline creation)
     if (isBaseline) {
@@ -217,7 +217,24 @@ async function main(): Promise<void> {
     } else if (!config.dryRun && config.slackWebhookUrl) {
       try {
         await sendSlackNotification(config.slackWebhookUrl, {
-          text: "DesignDigest: No changes detected across all monitored files.",
+          text: "✅ No changes detected",
+          blocks: [
+            {
+              type: "header",
+              text: {
+                type: "plain_text",
+                text: "✅ No changes detected",
+                emoji: true,
+              },
+            },
+            {
+              type: "section",
+              text: {
+                type: "mrkdwn",
+                text: "All monitored Figma files are unchanged.",
+              },
+            },
+          ],
         });
         console.log("Slack notification sent (no changes).");
       } catch (err) {


### PR DESCRIPTION
## 概要
変更なし時のSlack通知メッセージを簡潔で視認性の高いBlock Kit形式に変更しました。

## 変更内容
- `src/diff.ts`: 変更なし時のSlack通知を簡潔なBlock Kit形式に変更
  - テキストを `✅ No changes detected` に短縮
  - Block Kitの `header` + `section` ブロックで視認性を向上
  - コンソールログにも✅絵文字を追加

## テスト方法
- `npm test` で全テスト通過を確認
- `npm run lint` でlintエラーなしを確認
- `npm run typecheck` で型エラーなしを確認
- `npm run diff:dry-run` で変更なし時のコンソール出力に✅が含まれることを確認

Closes #39