### PR TITLE
docs: ページ単位AIサマリーのコスト・レイテンシ特性をREADMEに反映

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ AI summaries are generated **per page** — each Figma page with changes trigger
 
 - **API calls per run** = number of pages with changes (across all monitored files)
 - **Fault isolation** — if one page's summary fails, other pages still get their summaries
-- **Parallel execution** — all page summaries are requested concurrently via `Promise.allSettled`
+- **Parallel execution (per file)** — for each Figma file, all changed pages in that file are requested concurrently via `Promise.allSettled`, while files themselves are processed sequentially
 
 #### Claude API cost estimate
 


### PR DESCRIPTION
## 概要

PR #49 でAIサマリーがページ単位生成に変更されたが、READMEの記述が「1回のAPI呼び出し」前提のままだったため、現在の実装に合わせて更新。

## 変更内容

- README.md のAIサマリーセクションを更新:
  - 「Per-page summary generation」セクションを新設し、ページ単位のAPI呼び出し・障害分離・並列実行を説明
  - コスト見積もりテーブルを「変更ページ数」ベースに変更
  - トークン見積もりをAPI呼び出し単位（per call）に修正

## テスト方法

- [ ] READMEのマークダウンが正しくレンダリングされることを確認
- [ ] `src/claude-summary.ts` の実装（`generatePageSummaries`）と記述が一致していることを確認

Closes #53