### PR TITLE
fix: findExistingIssueのcount上限を100に引き上げ、上限到達時に警告ログを出力

### DIFF
--- a/src/backlog-client.test.ts
+++ b/src/backlog-client.test.ts
@@ -165,7 +165,7 @@ describe("findExistingIssue", () => {
 
     const url = fetchSpy.mock.calls[0][0] as string;
     expect(url).toContain("keyword=%5BDesignDigest%5D+abc123+page%3AHome");
-    expect(url).toContain("count=20");
+    expect(url).toContain("count=100");
   });
 
   it("excludes closed issues (status.id === 4)", async () => {
@@ -240,6 +240,43 @@ describe("findExistingIssue", () => {
     await expect(findExistingIssue(mockConfig, "[DesignDigest] abc123 node:1:2")).rejects.toThrow(
       "Backlog API search failed: 401 Unauthorized",
     );
+  });
+
+  it("logs warning when results reach the limit (100)", async () => {
+    const issues = Array.from({ length: 100 }, (_, i) => ({
+      id: i + 1,
+      issueKey: `TEST-${i + 1}`,
+      summary: "changes",
+      description: "no match here",
+    }));
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify(issues), { status: 200 }),
+    );
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await findExistingIssue(mockConfig, "[DesignDigest] abc123 node:1:2");
+
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(warnSpy.mock.calls[0][0]).toContain("100 issues (limit: 100)");
+    warnSpy.mockRestore();
+  });
+
+  it("does not log warning when results are below limit", async () => {
+    const issues = Array.from({ length: 99 }, (_, i) => ({
+      id: i + 1,
+      issueKey: `TEST-${i + 1}`,
+      summary: "changes",
+      description: "no match here",
+    }));
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify(issues), { status: 200 }),
+    );
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await findExistingIssue(mockConfig, "[DesignDigest] abc123 node:1:2");
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 });
 

--- a/src/backlog-client.ts
+++ b/src/backlog-client.ts
@@ -47,11 +47,13 @@ export async function findExistingIssue(
   // so we fetch without status filter and exclude closed issues client-side.
   const CLOSED_STATUS_ID = 4;
 
+  const MAX_COUNT = 100;
+
   const params = new URLSearchParams({
     apiKey: config.apiKey,
     "projectId[]": config.projectId,
     keyword: marker,
-    count: "20",
+    count: String(MAX_COUNT),
     sort: "created",
     order: "desc",
   });
@@ -68,6 +70,13 @@ export async function findExistingIssue(
 
   const issues: BacklogIssueListItem[] = await response.json();
   if (issues.length === 0) return null;
+
+  if (issues.length >= MAX_COUNT) {
+    console.warn(
+      `[DesignDigest] Warning: Backlog search returned ${issues.length} issues (limit: ${MAX_COUNT}). ` +
+        `Marker match may be missed. Consider narrowing the search keyword.`,
+    );
+  }
 
   // Validate marker exact line match in description to prevent partial matches
   // (e.g., "node:1:2" matching "node:1:23"), and exclude closed issues.


### PR DESCRIPTION
## 概要
Backlog APIの`findExistingIssue()`で取得件数が20件に制限されていたため、同一マーカーキーワードに部分一致するIssueが20件を超える場合にマーカー検出漏れが発生する可能性があった。取得件数をBacklog API最大値の100に引き上げ、上限到達時に警告ログを出力するようにした。

## 変更内容
- `src/backlog-client.ts`: `count`を20→100に変更、取得件数が上限に達した場合に`console.warn`で警告を出力
- `src/backlog-client.test.ts`: `count=100`の検証に更新、警告ログ出力/非出力のテストを追加

## テスト方法
- `npm test` で全テスト通過を確認
- `npm run lint && npm run typecheck` でエラーなしを確認

Closes #57