### PR TITLE
巨大FigmaファイルのERR_STRING_TOO_LONGでチャンク分割フォールバックを発動

### DIFF
--- a/src/figma-client.test.ts
+++ b/src/figma-client.test.ts
@@ -8,6 +8,7 @@ import {
   adaptiveBatchSize,
   fetchFileProactive,
   fetchNodesProactive,
+  isPayloadTooLargeError,
 } from "./figma-client.js";
 import type { FigmaNode, FigmaFile, FigmaVersion } from "./figma-client.js";
 
@@ -574,5 +575,45 @@ describe("fetchNodesProactive", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     // Large nodes are NOT reported as chunked when depth=1
     expect(chunkedNodes).toEqual([]);
+  });
+});
+
+describe("isPayloadTooLargeError", () => {
+  it("detects Figma API 'request too large' error", () => {
+    expect(isPayloadTooLargeError(new Error("Request too large"))).toBe(true);
+  });
+
+  it("detects Figma API 'try a smaller request' error", () => {
+    expect(isPayloadTooLargeError(new Error("Try a smaller request"))).toBe(true);
+  });
+
+  it("detects 'invalid string length' error", () => {
+    expect(isPayloadTooLargeError(new Error("Invalid string length"))).toBe(true);
+  });
+
+  it("detects 'allocation failed' error", () => {
+    expect(isPayloadTooLargeError(new Error("JavaScript heap out of memory - allocation failed"))).toBe(true);
+  });
+
+  it("detects ERR_STRING_TOO_LONG by error code", () => {
+    const err = new Error("Cannot create a string longer than 0x1fffffe8 characters");
+    (err as Error & { code: string }).code = "ERR_STRING_TOO_LONG";
+    expect(isPayloadTooLargeError(err)).toBe(true);
+  });
+
+  it("detects ERR_STRING_TOO_LONG by message pattern", () => {
+    expect(
+      isPayloadTooLargeError(new Error("Cannot create a string longer than 0x1fffffe8 characters")),
+    ).toBe(true);
+  });
+
+  it("returns false for unrelated errors", () => {
+    expect(isPayloadTooLargeError(new Error("Network timeout"))).toBe(false);
+    expect(isPayloadTooLargeError(new Error("404 Not Found"))).toBe(false);
+  });
+
+  it("handles non-Error values", () => {
+    expect(isPayloadTooLargeError("request too large")).toBe(true);
+    expect(isPayloadTooLargeError("something else")).toBe(false);
   });
 });

--- a/src/figma-client.ts
+++ b/src/figma-client.ts
@@ -430,13 +430,19 @@ export function sanitizeNode<T>(node: T): T {
  * Shared across REST adapter (API response errors) and design-check (file parse errors).
  */
 export function isPayloadTooLargeError(err: unknown): boolean {
+  // Check error code first (e.g. Node.js ERR_STRING_TOO_LONG)
+  if (err instanceof Error && "code" in err) {
+    const code = (err as Error & { code?: string }).code;
+    if (code === "ERR_STRING_TOO_LONG") return true;
+  }
   const message = (err instanceof Error ? err.message : String(err)).toLowerCase();
   return (
     message.includes("request too large") ||
     message.includes("try a smaller request") ||
     message.includes("invalid string length") ||
     message.includes("allocation failed") ||
-    message.includes("out of memory")
+    message.includes("out of memory") ||
+    message.includes("string longer than")
   );
 }
 


### PR DESCRIPTION
## Summary
- `isPayloadTooLargeError()` で Node.js の `ERR_STRING_TOO_LONG` エラーコードおよびメッセージパターンをキャッチ対象に追加
- 巨大Figmaファイルのレスポンスパース時に文字列長上限を超えた場合、既存のチャンク分割フォールバックが正しく発動するように修正
- `isPayloadTooLargeError()` のユニットテストを追加（8ケース）

Closes #87

## Test plan
- [x] 既存テスト全211件パス
- [x] `isPayloadTooLargeError` の新規テスト8件パス（ERR_STRING_TOO_LONG code検出、メッセージパターン検出、非該当エラー、非Error値）
- [x] lint / typecheck パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)