### PR TITLE
初回実行（ベースライン作成）時にもSlack通知を送信する

### DIFF
--- a/src/diff.ts
+++ b/src/diff.ts
@@ -188,9 +188,17 @@ async function main(): Promise<void> {
           if (prefix.length + pageList.length <= SLACK_TEXT_LIMIT) {
             text = prefix + pageList;
           } else {
+            // Truncate by whole lines to avoid cutting mid-line or mid-character
             const truncatedNote = "\n(truncated)";
             const available = Math.max(0, SLACK_TEXT_LIMIT - prefix.length - truncatedNote.length);
-            text = prefix + pageList.slice(0, available) + truncatedNote;
+            const lines = pageList.split("\n");
+            let truncated = "";
+            for (const line of lines) {
+              const next = truncated ? truncated + "\n" + line : line;
+              if (next.length > available) break;
+              truncated = next;
+            }
+            text = prefix + (truncated || lines[0]) + truncatedNote;
           }
           baselineBlocks.push({
             type: "section",


### PR DESCRIPTION
## 概要
初回実行（前回スナップショットがない状態）でベースライン作成時にもSlack通知を送信するように変更。これにより、新しいFigmaファイルの監視開始を即座に確認でき、ファイルに含まれるページ構成を初回から把握できる。

## 変更内容
- `src/diff.ts`:
  - `processFile` がベースライン作成時に `pages` データを返すように変更
  - `main` のベースライン分岐で「📋 Baseline created — now monitoring」通知を送信
  - 通知にはファイル名（Figmaリンク付き）とページ一覧を含む
  - `DRY_RUN=true` / `SLACK_WEBHOOK_URL` 未設定時は従来通りスキップ

## テスト方法
- `npm run typecheck` — 型チェック通過
- `npm test` — 全211テスト通過
- `npm run lint` — lint通過
- 2回目以降の通常動作（変更検出・変更なし通知）に影響なし（既存ロジック未変更）

Closes #89