### PR TITLE
feat: backlog-client のページネーション対応

### DIFF
--- a/src/backlog-client.test.ts
+++ b/src/backlog-client.test.ts
@@ -166,6 +166,7 @@ describe("findExistingIssue", () => {
     const url = fetchSpy.mock.calls[0][0] as string;
     expect(url).toContain("keyword=%5BDesignDigest%5D+abc123+page%3AHome");
     expect(url).toContain("count=100");
+    expect(url).toContain("offset=0");
   });
 
   it("excludes closed issues (status.id === 4)", async () => {
@@ -242,22 +243,92 @@ describe("findExistingIssue", () => {
     );
   });
 
-  it("logs warning when results reach the limit (100)", async () => {
-    const issues = Array.from({ length: 100 }, (_, i) => ({
+  it("paginates when first page is full and finds match on second page", async () => {
+    const page1Issues = Array.from({ length: 100 }, (_, i) => ({
       id: i + 1,
       issueKey: `TEST-${i + 1}`,
       summary: "changes",
       description: "no match here",
     }));
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      new Response(JSON.stringify(issues), { status: 200 }),
-    );
+    const page2Match = {
+      id: 101,
+      issueKey: "TEST-101",
+      summary: "found it",
+      description: "[DesignDigest] abc123 node:1:2\n\ntest",
+      status: { id: 1, name: "Open" },
+    };
+    const fetchSpy = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(page1Issues), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([page2Match]), { status: 200 }),
+      );
+
+    const result = await findExistingIssue(mockConfig, "[DesignDigest] abc123 node:1:2");
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const secondUrl = fetchSpy.mock.calls[1][0] as string;
+    expect(secondUrl).toContain("offset=100");
+    expect(result).toEqual({
+      id: 101,
+      issueKey: "TEST-101",
+      summary: "found it",
+      description: "[DesignDigest] abc123 node:1:2\n\ntest",
+    });
+  });
+
+  it("stops pagination when a page returns fewer than MAX_COUNT results", async () => {
+    const page1Issues = Array.from({ length: 100 }, (_, i) => ({
+      id: i + 1,
+      issueKey: `TEST-${i + 1}`,
+      summary: "changes",
+      description: "no match here",
+    }));
+    const page2Issues = Array.from({ length: 50 }, (_, i) => ({
+      id: 101 + i,
+      issueKey: `TEST-${101 + i}`,
+      summary: "changes",
+      description: "no match here",
+    }));
+    const fetchSpy = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(page1Issues), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(page2Issues), { status: 200 }),
+      );
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const result = await findExistingIssue(mockConfig, "[DesignDigest] abc123 node:1:2");
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(result).toBeNull();
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("logs warning when pagination limit is reached", async () => {
+    // MAX_PAGES = 10, each page returns 100 issues = 1000 total
+    const fullPage = Array.from({ length: 100 }, (_, i) => ({
+      id: i + 1,
+      issueKey: `TEST-${i + 1}`,
+      summary: "changes",
+      description: "no match here",
+    }));
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    for (let p = 0; p < 10; p++) {
+      fetchSpy.mockResolvedValueOnce(
+        new Response(JSON.stringify(fullPage), { status: 200 }),
+      );
+    }
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     await findExistingIssue(mockConfig, "[DesignDigest] abc123 node:1:2");
 
+    expect(fetchSpy).toHaveBeenCalledTimes(10);
     expect(warnSpy).toHaveBeenCalledOnce();
-    expect(warnSpy.mock.calls[0][0]).toContain("100 issues (limit: 100)");
+    expect(warnSpy.mock.calls[0][0]).toContain("1000 issues fetched across 10 pages");
     warnSpy.mockRestore();
   });
 

--- a/src/backlog-client.ts
+++ b/src/backlog-client.ts
@@ -48,54 +48,72 @@ export async function findExistingIssue(
   const CLOSED_STATUS_ID = 4;
 
   const MAX_COUNT = 100;
+  // Safety limit to avoid excessive API calls in very large projects
+  const MAX_PAGES = 10;
 
-  const params = new URLSearchParams({
-    apiKey: config.apiKey,
-    "projectId[]": config.projectId,
-    keyword: marker,
-    count: String(MAX_COUNT),
-    sort: "created",
-    order: "desc",
-  });
+  const escapedMarker = marker.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const markerRegex = new RegExp(`(^|\\r?\\n)${escapedMarker}(\\r?\\n|$)`);
 
-  const url = `${baseUrl(config.spaceId)}/issues?${params}`;
-  const response = await fetch(url);
+  let offset = 0;
+  let totalFetched = 0;
 
-  if (!response.ok) {
-    const body = await response.text().catch(() => "");
-    throw new Error(
-      `Backlog API search failed: ${response.status} ${response.statusText}${body ? ` - ${body}` : ""}`,
+  for (let page = 0; page < MAX_PAGES; page++) {
+    const params = new URLSearchParams({
+      apiKey: config.apiKey,
+      "projectId[]": config.projectId,
+      keyword: marker,
+      count: String(MAX_COUNT),
+      offset: String(offset),
+      sort: "created",
+      order: "desc",
+    });
+
+    const url = `${baseUrl(config.spaceId)}/issues?${params}`;
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      throw new Error(
+        `Backlog API search failed: ${response.status} ${response.statusText}${body ? ` - ${body}` : ""}`,
+      );
+    }
+
+    const issues: BacklogIssueListItem[] = await response.json();
+    if (issues.length === 0) break;
+
+    totalFetched += issues.length;
+
+    // Validate marker exact line match in description to prevent partial matches
+    // (e.g., "node:1:2" matching "node:1:23"), and exclude closed issues.
+    const match = issues.find(
+      (issue) =>
+        issue.description != null &&
+        markerRegex.test(issue.description) &&
+        issue.status?.id !== CLOSED_STATUS_ID,
     );
+    if (match) {
+      return {
+        id: match.id,
+        issueKey: match.issueKey,
+        summary: match.summary,
+        description: match.description,
+      };
+    }
+
+    // Last page — no more results to fetch
+    if (issues.length < MAX_COUNT) break;
+
+    offset += issues.length;
   }
 
-  const issues: BacklogIssueListItem[] = await response.json();
-  if (issues.length === 0) return null;
-
-  if (issues.length >= MAX_COUNT) {
+  if (totalFetched >= MAX_COUNT * MAX_PAGES) {
     console.warn(
-      `[DesignDigest] Warning: Backlog search returned ${issues.length} issues (limit: ${MAX_COUNT}). ` +
+      `[DesignDigest] Warning: Backlog search reached pagination limit (${totalFetched} issues fetched across ${MAX_PAGES} pages). ` +
         `Marker match may be missed. Consider narrowing the search keyword.`,
     );
   }
 
-  // Validate marker exact line match in description to prevent partial matches
-  // (e.g., "node:1:2" matching "node:1:23"), and exclude closed issues.
-  const escapedMarker = marker.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const markerRegex = new RegExp(`(^|\\r?\\n)${escapedMarker}(\\r?\\n|$)`);
-  const match = issues.find(
-    (issue) =>
-      issue.description != null &&
-      markerRegex.test(issue.description) &&
-      issue.status?.id !== CLOSED_STATUS_ID,
-  );
-  if (!match) return null;
-
-  return {
-    id: match.id,
-    issueKey: match.issueKey,
-    summary: match.summary,
-    description: match.description,
-  };
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- `findExistingIssue` にページネーション対応を追加し、Backlog API の検索上限（100件）到達時に自動的に次ページを取得するように改善
- 最大10ページ（1000件）まで検索を継続し、安全制限付きで大規模プロジェクトでのマーカー検出ミスを防止
- ページネーション上限到達時の警告メッセージを強化

## Changes
- `src/backlog-client.ts`: `findExistingIssue` をページネーション対応にリファクタリング（offset パラメータ、MAX_PAGES 制限、ページごとのマッチ検索）
- `src/backlog-client.test.ts`: ページネーション関連のテストを追加（2ページ目でマッチ、途中ページで終了、上限到達時の警告）

## Test plan
- [x] 既存テスト全225件パス
- [x] 新規ページネーションテスト3件追加・パス
- [x] lint・typecheck クリア

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)