### PR TITLE
GitHub Actions ワークフローに環境変数の受け渡し漏れを修正

### DIFF
--- a/.github/workflows/figma-diff.yml
+++ b/.github/workflows/figma-diff.yml
@@ -49,9 +49,23 @@ jobs:
           FIGMA_FILE_KEY: ${{ secrets.FIGMA_FILE_KEY }}
           FIGMA_WATCH_PAGES: ${{ vars.FIGMA_WATCH_PAGES }}
           FIGMA_WATCH_NODE_IDS: ${{ vars.FIGMA_WATCH_NODE_IDS }}
+          FIGMA_NODE_DEPTH: ${{ vars.FIGMA_NODE_DEPTH }}
+          FIGMA_BATCH_SIZE: ${{ vars.FIGMA_BATCH_SIZE }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLAUDE_SUMMARY_ENABLED: ${{ vars.CLAUDE_SUMMARY_ENABLED }}
+          GITHUB_ISSUE_ENABLED: ${{ vars.GITHUB_ISSUE_ENABLED }}
+          GITHUB_ISSUE_TOKEN: ${{ secrets.GITHUB_ISSUE_TOKEN }}
+          GITHUB_ISSUE_REPO: ${{ vars.GITHUB_ISSUE_REPO }}
+          GITHUB_ISSUE_LABELS: ${{ vars.GITHUB_ISSUE_LABELS }}
+          GITHUB_ISSUE_ASSIGNEES: ${{ vars.GITHUB_ISSUE_ASSIGNEES }}
+          BACKLOG_ENABLED: ${{ vars.BACKLOG_ENABLED }}
+          BACKLOG_API_KEY: ${{ secrets.BACKLOG_API_KEY }}
+          BACKLOG_SPACE_ID: ${{ vars.BACKLOG_SPACE_ID }}
+          BACKLOG_PROJECT_ID: ${{ vars.BACKLOG_PROJECT_ID }}
+          BACKLOG_ISSUE_TYPE_ID: ${{ vars.BACKLOG_ISSUE_TYPE_ID }}
+          BACKLOG_PRIORITY_ID: ${{ vars.BACKLOG_PRIORITY_ID }}
+          BACKLOG_ASSIGNEE_ID: ${{ vars.BACKLOG_ASSIGNEE_ID }}
 
       - name: Upload snapshot
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## 概要

`figma-diff.yml` ワークフローで `src/config.ts` が参照する環境変数の一部がワークフロー定義に渡されていなかった問題を修正。

## 変更内容

- `.github/workflows/figma-diff.yml` に以下の環境変数を追加:
  - `FIGMA_NODE_DEPTH`, `FIGMA_BATCH_SIZE` (Figma取得設定)
  - `GITHUB_ISSUE_ENABLED`, `GITHUB_ISSUE_TOKEN`, `GITHUB_ISSUE_REPO`, `GITHUB_ISSUE_LABELS`, `GITHUB_ISSUE_ASSIGNEES` (GitHub Issue連携)
  - `BACKLOG_ENABLED`, `BACKLOG_API_KEY`, `BACKLOG_SPACE_ID`, `BACKLOG_PROJECT_ID`, `BACKLOG_ISSUE_TYPE_ID`, `BACKLOG_PRIORITY_ID`, `BACKLOG_ASSIGNEE_ID` (Backlog連携)
- API キー系は `secrets`、設定値系は `vars` を使用

## テスト方法

- [ ] `src/config.ts` の環境変数一覧と `figma-diff.yml` の `env` セクションが一致していることを確認
- [ ] GitHub Actions で実際にワークフローが正常に動作することを確認

Closes #105