### PR TITLE
github-issue-client.ts の unknown 型を具体的な型に置換

### DIFF
--- a/src/github-issue-client.ts
+++ b/src/github-issue-client.ts
@@ -19,7 +19,7 @@ export interface GitHubIssueResponse {
   title: string;
   html_url: string;
   body: string | null;
-  pull_request?: unknown;
+  pull_request?: { url: string };
 }
 
 /**
@@ -140,7 +140,7 @@ export async function createGitHubIssue(
 ): Promise<GitHubIssue> {
   const url = `https://api.github.com/repos/${config.owner}/${config.repo}/issues`;
 
-  const payload: Record<string, unknown> = { title, body };
+  const payload: { title: string; body: string; labels?: string[]; assignees?: string[] } = { title, body };
   if (config.labels.length > 0) {
     payload.labels = config.labels;
   }


### PR DESCRIPTION
## 概要

`src/` 全体の `any`/`unknown` 型を調査し、具体的な型定義に移行可能な箇所を特定・修正しました。

## 変更内容

- `src/github-issue-client.ts`:
  - `GitHubIssueResponse.pull_request` を `unknown` → `{ url: string }` に型付け（GitHub API レスポンス仕様に準拠）
  - `createGitHubIssue` の `payload` を `Record<string, unknown>` → 具体的なインターフェース型 `{ title: string; body: string; labels?: string[]; assignees?: string[] }` に変更

## 調査結果

`src/` 全体で `any` 型の使用は0箇所。`unknown` は約20箇所あり、以下の理由で大部分は正当な使用:

- **FigmaNode index signature** (`[key: string]: unknown`): Figma API 境界のため `unknown` が適切
- **ChangeEntry.oldValue/newValue**: deep-diff 出力で型が不定のため `unknown` が適切
- **型ガード関数** (`isColorObject`, `isValidNode`, `isPayloadTooLargeError`): `unknown` → 具体型への narrowing が本来の用途
- **formatVal/formatValue**: 任意値のフォーマッタとして `unknown` が適切

## テスト方法

- `npm test` — 全225テスト パス
- `npm run lint` — エラーなし
- `npm run typecheck` — エラーなし

Closes #96