### PR TITLE
chore: .env.example の SLACK_ICON 変数を config.ts に反映

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,8 @@ export interface Config {
   figmaWatchPages: string[];
   figmaWatchNodeIds: string[];
   slackWebhookUrl: string | undefined;
+  slackIconUrl: string | undefined;
+  slackIconEmoji: string | undefined;
   anthropicApiKey: string | undefined;
   claudeSummaryEnabled: boolean;
   githubIssueEnabled: boolean;
@@ -37,6 +39,8 @@ export function loadConfig(): Config {
     figmaWatchPages: csvList("FIGMA_WATCH_PAGES"),
     figmaWatchNodeIds: csvList("FIGMA_WATCH_NODE_IDS"),
     slackWebhookUrl: process.env.SLACK_WEBHOOK_URL || undefined,
+    slackIconUrl: process.env.SLACK_ICON_URL || undefined,
+    slackIconEmoji: process.env.SLACK_ICON_EMOJI || undefined,
     anthropicApiKey: process.env.ANTHROPIC_API_KEY || undefined,
     claudeSummaryEnabled: process.env.CLAUDE_SUMMARY_ENABLED === "true",
     githubIssueEnabled: process.env.GITHUB_ISSUE_ENABLED === "true",

--- a/src/design-check.ts
+++ b/src/design-check.ts
@@ -32,7 +32,7 @@ import {
   groupByPage,
 } from "./diff-engine.js";
 import { generatePageSummaries } from "./claude-summary.js";
-import { sendSlackNotification } from "./notify.js";
+import { sendSlackNotification, slackIconFields } from "./notify.js";
 
 interface CliArgs {
   inputPaths: string[];
@@ -132,6 +132,8 @@ async function main(): Promise<void> {
   const snapshotDir = process.env.SNAPSHOT_DIR || "./snapshots";
   const dryRun = process.env.DRY_RUN === "true";
   const slackWebhookUrl = process.env.SLACK_WEBHOOK_URL;
+  const slackIconUrl = process.env.SLACK_ICON_URL;
+  const slackIconEmoji = process.env.SLACK_ICON_EMOJI;
   const anthropicApiKey = process.env.ANTHROPIC_API_KEY;
 
   // Resolve input paths (expand --input-dir)
@@ -217,6 +219,7 @@ async function main(): Promise<void> {
               text: { type: "mrkdwn", text: "MCP-based design check: no changes found." },
             },
           ],
+          ...slackIconFields(slackIconUrl, slackIconEmoji),
         });
         console.log("Slack notification sent (no changes).");
       } catch (err) {
@@ -258,7 +261,7 @@ async function main(): Promise<void> {
       });
     }
     const fallbackText = formatSlackReport(fileKey, changes);
-    await sendSlackNotification(slackWebhookUrl, { text: fallbackText, blocks });
+    await sendSlackNotification(slackWebhookUrl, { text: fallbackText, blocks, ...slackIconFields(slackIconUrl, slackIconEmoji) });
     console.log("Slack notification sent.");
   } else if (dryRun) {
     console.log("\nDry run mode — skipping notifications.");

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -14,7 +14,7 @@ import {
   escapeSlackLinkText,
 } from "./diff-engine.js";
 import { generatePageSummaries } from "./claude-summary.js";
-import { sendSlackNotification } from "./notify.js";
+import { sendSlackNotification, slackIconFields } from "./notify.js";
 import {
   fetchOpenIssues,
   findExistingGitHubIssue,
@@ -229,6 +229,7 @@ async function main(): Promise<void> {
         await sendSlackNotification(config.slackWebhookUrl, {
           text: "📋 Baseline created — now monitoring",
           blocks: finalBaselineBlocks,
+          ...slackIconFields(config.slackIconUrl, config.slackIconEmoji),
         });
         console.log("Slack notification sent (baseline created).");
       } catch (err) {
@@ -266,6 +267,7 @@ async function main(): Promise<void> {
               },
             },
           ],
+          ...slackIconFields(config.slackIconUrl, config.slackIconEmoji),
         });
         console.log("Slack notification sent (no changes).");
       } catch (err) {
@@ -360,6 +362,7 @@ async function main(): Promise<void> {
     await sendSlackNotification(config.slackWebhookUrl, {
       text: fallbackText,
       blocks,
+      ...slackIconFields(config.slackIconUrl, config.slackIconEmoji),
     });
     console.log("Slack notification sent.");
   } else if (config.dryRun) {
@@ -623,6 +626,7 @@ main().catch(async (err) => {
                 }]
               : []),
           ],
+          ...slackIconFields(process.env.SLACK_ICON_URL, process.env.SLACK_ICON_EMOJI),
         }, controller.signal);
         console.log("Error notification sent to Slack.");
       } finally {

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -3,6 +3,15 @@ import type { SlackBlock } from "./diff-engine.js";
 export interface SlackPayload {
   text: string;
   blocks?: SlackBlock[];
+  icon_url?: string;
+  icon_emoji?: string;
+}
+
+export function slackIconFields(iconUrl?: string, iconEmoji?: string): Pick<SlackPayload, "icon_url" | "icon_emoji"> {
+  return {
+    ...(iconUrl && { icon_url: iconUrl }),
+    ...(iconEmoji && { icon_emoji: iconEmoji }),
+  };
 }
 
 export async function sendSlackNotification(


### PR DESCRIPTION
## Summary
- `.env.example` に定義済みだが未使用だった `SLACK_ICON_URL` / `SLACK_ICON_EMOJI` を `Config` インターフェースと `loadConfig()` に追加
- `notify.ts` に `slackIconFields()` ヘルパーを追加し、全 Slack 通知で `icon_url` / `icon_emoji` を送信
- `diff.ts` (4箇所) と `design-check.ts` (2箇所) の全通知呼び出しに適用

Closes #100

## Test plan
- [x] `npm run typecheck` — pass
- [x] `npm run lint` — pass
- [x] `npm test` — 236 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)