### PR TITLE
chore: README の generatePageSummaries 記述を実装に合致させる

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ AI summaries are generated **per page** — each Figma page with changes trigger
 
 - **API calls per run** = number of pages with changes (across all monitored files)
 - **Fault isolation** — if one page's summary fails, other pages still get their summaries
-- **Parallel execution (per file)** — for each Figma file, all changed pages in that file are requested concurrently via `Promise.allSettled`, while files themselves are processed sequentially
+- **Bounded concurrency (per file)** — for each Figma file, changed pages are summarized with bounded concurrency (default: 3 concurrent requests) while files themselves are processed sequentially
 
 #### Claude API cost estimate
 


### PR DESCRIPTION
## Summary
- README の AI サマリー並列実行の記述が実装と不一致だった点を修正
- `Promise.allSettled` による無制限並列 → `allSettledWithConcurrency`（デフォルト同時実行数3）による制限付き並列

Closes #101

## Test plan
- [x] `npm run typecheck` — pass
- [x] `npm run lint` — pass
- [x] `npm test` — 236 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)