### PR TITLE
feat: スナップショットのアトミック書き込み

### DIFF
--- a/src/snapshot.test.ts
+++ b/src/snapshot.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtemp, rm, writeFile, mkdir, truncate } from "node:fs/promises";
+import { mkdtemp, rm, writeFile, mkdir, truncate, readdir } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -145,6 +145,71 @@ describe("snapshot page file migration", () => {
     expect(loaded!.pages["Page A"]).toEqual(pages["Page A"]);
     expect(loaded!.pages["page a"]).toEqual(pages["page a"]);
     expect(loaded!.versionId).toBe("v1");
+  });
+});
+
+describe("atomic write (no leftover .tmp files)", () => {
+  let tmpDir: string;
+  const fileKey = "testFile123";
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "snapshot-atomic-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("savePage leaves no .tmp files after successful write", async () => {
+    const node = makePageNode("0:1", "Page A");
+    await savePage(tmpDir, fileKey, "Page A", node);
+
+    const pagesDir = join(tmpDir, fileKey, "pages");
+    const files = await readdir(pagesDir);
+    const tmpFiles = files.filter((f) => f.endsWith(".tmp"));
+    expect(tmpFiles).toEqual([]);
+
+    // Verify the page was written correctly
+    const loaded = await loadPage(tmpDir, fileKey, "Page A");
+    expect(loaded).toEqual(node);
+  });
+
+  it("saveSnapshotMeta leaves no .tmp files after successful write", async () => {
+    await saveSnapshotMeta(tmpDir, fileKey, {
+      timestamp: "2026-01-01T00:00:00Z",
+      pageNames: ["Page A"],
+    });
+
+    const dir = join(tmpDir, fileKey);
+    const files = await readdir(dir);
+    const tmpFiles = files.filter((f) => f.endsWith(".tmp"));
+    expect(tmpFiles).toEqual([]);
+
+    // Verify meta was written correctly
+    const meta = await loadSnapshotMeta(tmpDir, fileKey);
+    expect(meta).not.toBeNull();
+    expect(meta!.pageNames).toEqual(["Page A"]);
+  });
+
+  it("saveSnapshot round-trip leaves no .tmp files", async () => {
+    const pages: Record<string, FigmaNode> = {
+      "Page A": makePageNode("0:1", "Page A"),
+      "Page B": makePageNode("0:2", "Page B"),
+    };
+    await saveSnapshot(tmpDir, fileKey, pages, "v1");
+
+    // Check no .tmp files in fileKey dir or pages subdir
+    const dirFiles = await readdir(join(tmpDir, fileKey));
+    expect(dirFiles.filter((f) => f.endsWith(".tmp"))).toEqual([]);
+
+    const pagesDir = join(tmpDir, fileKey, "pages");
+    const pageFiles = await readdir(pagesDir);
+    expect(pageFiles.filter((f) => f.endsWith(".tmp"))).toEqual([]);
+
+    // Verify round-trip
+    const loaded = await loadSnapshot(tmpDir, fileKey);
+    expect(loaded).not.toBeNull();
+    expect(Object.keys(loaded!.pages)).toEqual(["Page A", "Page B"]);
   });
 });
 

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -4,6 +4,17 @@ import { join } from "node:path";
 import { createHash } from "node:crypto";
 import type { FigmaNode } from "./figma-client.js";
 
+/**
+ * Write data to a file atomically by writing to a temporary file first,
+ * then renaming it to the target path. This prevents partial/corrupt files
+ * if the process crashes mid-write.
+ */
+async function writeFileAtomic(filePath: string, data: string): Promise<void> {
+  const tmpPath = `${filePath}.tmp`;
+  await writeFile(tmpPath, data);
+  await rename(tmpPath, filePath);
+}
+
 /** Maximum legacy snapshot file size in bytes (500 MiB). Files exceeding this are renamed aside to prevent OOM. */
 export const LEGACY_SNAPSHOT_MAX_BYTES = 500 * 1024 * 1024;
 
@@ -286,7 +297,7 @@ export async function saveSnapshotMeta(
     await mkdir(dirPath, { recursive: true });
   }
   const data: SnapshotMeta = { ...meta, fileKey };
-  await writeFile(metaPath(dir, fileKey), JSON.stringify(data, null, 2));
+  await writeFileAtomic(metaPath(dir, fileKey), JSON.stringify(data, null, 2));
 }
 
 /**
@@ -371,6 +382,15 @@ function writeNodeStream(filePath: string, node: FigmaNode): Promise<void> {
 }
 
 /**
+ * Atomic variant of writeNodeStream: writes to a temp file then renames.
+ */
+async function writeNodeStreamAtomic(filePath: string, node: FigmaNode): Promise<void> {
+  const tmpPath = `${filePath}.tmp`;
+  await writeNodeStream(tmpPath, node);
+  await rename(tmpPath, filePath);
+}
+
+/**
  * Save a single page to its own file.
  * Cleans up legacy encodeURIComponent-based file if it exists.
  */
@@ -386,11 +406,11 @@ export async function savePage(
   }
   const filePath = pageFilePath(dir, fileKey, pageName);
   try {
-    await writeFile(filePath, JSON.stringify(node, null, 2));
+    await writeFileAtomic(filePath, JSON.stringify(node, null, 2));
   } catch (err) {
     if (err instanceof RangeError) {
       // Covers both "Invalid string length" and "Maximum call stack size exceeded"
-      await writeNodeStream(filePath, node);
+      await writeNodeStreamAtomic(filePath, node);
     } else {
       throw err;
     }


### PR DESCRIPTION
## 概要

ページ逐次処理中のプロセスクラッシュによるスナップショット不整合を防止するため、全書き込みパスをアトミック化。tempファイルに書き出してから `rename()` で置き換える方式を採用。

## 変更内容

- `src/snapshot.ts`: `writeFileAtomic()` ヘルパーを追加し、`saveSnapshotMeta`・`savePage`・`writeNodeStream` の全書き込みパスで使用
- `src/snapshot.test.ts`: アトミック書き込み後に `.tmp` ファイルが残らないことを検証するテストを3件追加

## テスト方法

- `npm test` で全267テスト（新規3件含む）がパスすることを確認
- `npm run typecheck` / `npm run lint` がエラーなしで通ることを確認

Closes #133